### PR TITLE
Insert maptiler key if not already in base url

### DIFF
--- a/memorymap_toolkit/context_processors.py
+++ b/memorymap_toolkit/context_processors.py
@@ -4,6 +4,17 @@ from django.conf import settings
 # Third Party Django apps
 from constance import config
 
+# Local
+from .utils import ensure_maptiler_key
+
 
 def site_settings(request):
-    return {'config': config}
+    # Create a modified config object that includes the processed BASE_MAP_STYLE_URL
+    config_dict = {
+        'BASE_MAP_STYLE_URL': ensure_maptiler_key(config.BASE_MAP_STYLE_URL, config.MAPTILER_KEY)
+    }
+    
+    return {
+        'config': config,
+        'config_base_map_style_url': config_dict['BASE_MAP_STYLE_URL']
+    }

--- a/memorymap_toolkit/utils.py
+++ b/memorymap_toolkit/utils.py
@@ -1,0 +1,37 @@
+from urllib.parse import urlparse, urlencode, parse_qs, urlunparse
+
+
+def ensure_maptiler_key(url, key):
+    """
+    Checks if a 'key' parameter exists in the URL. 
+    If missing or empty, it adds/updates it.
+
+    >>> base_url = "https://api.maptiler.com/maps/landscape-v4/style.json"
+    >>> my_key = "YOUR_SECURE_KEY"
+
+    >>> ensure_maptiler_key(base_url, my_key)
+    'https://api.maptiler.com/maps/landscape-v4/style.json?key=YOUR_SECURE_KEY'
+
+    >>> already_has_key = f"{base_url}?key=EXISTING_KEY"
+    >>> ensure_maptiler_key(already_has_key, my_key)
+    'https://api.maptiler.com/maps/landscape-v4/style.json?key=EXISTING_KEY'
+    """
+    # 1. Parse the URL into components
+    url_parts = list(urlparse(url))
+    
+    # 2. Parse the query parameters into a dictionary
+    # parse_qs returns a list for each key (e.g., {'key': ['XXX']})
+    query_params = parse_qs(url_parts[4])
+    
+    # 3. Check if 'key' is present and has a value
+    if 'key' not in query_params or not query_params['key'][0]:
+        query_params['key'] = [key]
+        
+        # 4. Re-encode the query string and put it back in the URL parts
+        url_parts[4] = urlencode(query_params, doseq=True)
+        
+    # 5. Reconstruct the full URL
+    result = urlunparse(url_parts)
+    print(f"Utils called with {url} and {key}. Got {result}")
+    return result
+

--- a/templates/mmt_map/index.html
+++ b/templates/mmt_map/index.html
@@ -75,7 +75,7 @@ const MmtMap = {
 
     	// Loads the correct map style source depending on whether the user is using a link to an external map style or has uploaded a file
 
-		let baseMapStyleUrl = '{{ config.BASE_MAP_STYLE_URL|safe }}';
+		let baseMapStyleUrl = '{{ config_base_map_style_url|safe }}';
 
 		let baseMapStyleFile = '{{ config.BASE_MAP_STYLE_FILE }}';
 


### PR DESCRIPTION
I had problems with `BASE_MAP_STYLE_URL`. It worked only if it contains a key. But this is different from `MAPTILER_KEY`. Now the two could be set separately.